### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/CEI-SSC-test01/5d2e3c92-3371-47a4-be6f-b38203d39697/99d23457-83ec-4275-869c-140ca80c8f5c/_apis/work/boardbadge/ca5eb334-3052-430c-802e-9caaaa3e2cc6)](https://dev.azure.com/CEI-SSC-test01/5d2e3c92-3371-47a4-be6f-b38203d39697/_boards/board/t/99d23457-83ec-4275-869c-140ca80c8f5c/Microsoft.RequirementCategory)
 # example-agile-project
 
 First edit goes here.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#5. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.